### PR TITLE
Allow extra apt lists for e.g. multiverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,11 @@ Requires an empty line at end of file.
 Optional file allowing to configure package installation. Use case is mainly for EULA (like ttf-mscorefonts-installer).
 Requires an empty line at end of file.
 
+## apt-lists
+Optional file allowing to configure extra apt repositories. Contents could be e.g.
+```
+deb http://archive.ubuntu.com/ubuntu quantal multiverse
+```
+
 
 [dokku]: https://github.com/progrium/dokku

--- a/pre-build
+++ b/pre-build
@@ -13,6 +13,11 @@ if [ -f $DIR/apt-repositories ]; then
         add-apt-repository -y "\$repository"
     done
 fi
+if [ -f $DIR/apt-lists ]; then
+    LISTS=\$(cat "$DIR/apt-lists" | tr "\\n" " ")
+    cp $DIR/apt-lists /etc/apt/sources.list.d/dokku-apt-lists.list
+    echo "-----> Injected lists: \$LISTS"
+fi
 if [ -f $DIR/apt-debconf ]; then
     cat "$DIR/apt-debconf" | while read conf; do
         echo \$conf | debconf-set-selections


### PR DESCRIPTION
Hi,

Awesome plugin. While trying to install ttf-mscorefonts-installer (as mentioned in README.md)  i needed the multiverse apt sources. I've added an option to add apt-sources like this.
