### PR TITLE
allow customizing sources.list

### DIFF
--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -9,6 +9,10 @@ DIR=/app
 
 COMMAND=$(cat <<EOF
 export DEBIAN_FRONTEND=noninteractive
+if [ -f $DIR/apt-sources-list ]; then
+    echo "-----> using customized sources.list ..."
+    mv -v $DIR/apt-sources-list /etc/apt/sources.list
+fi
 if [ -f $DIR/apt-repositories ]; then
     apt-get update
     apt-get install -y software-properties-common apt-transport-https


### PR DESCRIPTION
Hi,

this tiny patch allows the customization if `/etc/apt/sources.list` before any `apt update` command is run

It is very helpful for us in China since the default repository is quite slow and we need apt mirrors.

Thanks.