### PR TITLE
feat: implement package cache using labels

### DIFF
--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -2,32 +2,72 @@
 set -eo pipefail
 [[ $DOKKU_TRACE ]] && set -x
 export DOCKER_BIN=${DOCKER_BIN:="docker"}
+source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+
+fn-clean-extended-app-images() {
+  declare APP="$1" IMAGE="$2"
+  local images
+
+  # remove dangling extended app images
+  "$DOCKER_BIN" rmi $("$DOCKER_BIN" images --format 'dangling=true' --format "label=com.dokku.app-name=sha-$APP" --quiet) &>/dev/null || true
+
+  images="$("$DOCKER_BIN" images --filter "label=com.dokku.app-name=sha-$APP" --quiet)"
+  for image in $images; do
+    if [[ "$("$DOCKER_BIN" inspect --format '{{(index .RepoTags 0)}}' "$image" 2>/dev/null)" != "$IMAGE" ]]; then
+      "$DOCKER_BIN" rmi "$image" &>/dev/null || true
+    fi
+  done
+}
 
 hook-apt-pre-build-buildpack() {
-  declare APP="$1"
+  declare APP="$1" SOURCECODE_WORK_DIR="$2"
   local IMAGE="dokku/$APP" DIR=/app
-  local COMMAND
+  local COMMAND CONTENT CONTENT_SHA INJECT_PACKAGES
 
-  echo "-----> Injecting apt repositories and packages ..."
+  if [[ -n "$SOURCECODE_WORK_DIR" ]]; then
+    pushd "$SOURCECODE_WORK_DIR" >/dev/null
+  fi
+
+  local APT_FILES=('apt-env' 'apt-preferences' 'apt-sources-list' 'apt-repositories' 'apt-debconf' 'apt-packages' 'dpkg-packages')
+  for file in "${APT_FILES[@]}"; do
+    if [[ -f "$file" ]]; then
+      INJECT_PACKAGES=true
+      local file_contents=$(<$file)
+      CONTENT="${CONTENT}\n${file}\n${file_contents}"
+    fi
+  done
+
+  if [[ -n "$SOURCECODE_WORK_DIR" ]]; then
+    popd >/dev/null
+  fi
+
+  if [[ "$INJECT_PACKAGES" != "true" ]]; then
+    return
+  fi
 
   COMMAND=$(
     cat <<EOF
+# $APP $IMAGE
+sleep 2
 export DEBIAN_FRONTEND=noninteractive
 if [ -f $DIR/apt-env ]; then
-    echo "-----> sourcing apt env ..."
+    echo "-----> Sourcing apt env"
     source $DIR/apt-env
 fi
 if [ -d $DIR/apt-preferences ]; then
-    echo "-----> injecting apt preferences ..."
+    echo "-----> Injecting apt preferences"
     mv -v $DIR/apt-preferences /etc/apt/preferences.d/90customizations
 fi
 if [ -f $DIR/apt-sources-list ]; then
-    echo "-----> using customized sources.list ..."
+    echo "-----> Using customized sources.list"
     mv -v $DIR/apt-sources-list /etc/apt/sources.list
 fi
 if [ -f $DIR/apt-repositories ]; then
-    apt-get update
+    echo "-----> Updating package list"
+    apt-get update >/dev/null
+    echo "-----> Installing required apt transport packages"
     apt-get install -y software-properties-common apt-transport-https
+    echo "-----> Installing custom apt repositories"
     cat "$DIR/apt-repositories" | while read repository; do
         if [ -n "\$repository" ]; then
             add-apt-repository -y "\$repository"
@@ -43,25 +83,39 @@ if [ -f $DIR/apt-debconf ]; then
 fi
 if [ -f $DIR/apt-packages ]; then
     PACKAGES=\$(cat "$DIR/apt-packages" | tr "\\n" " ")
-    apt-get update
+    echo "-----> Updating package list"
+    apt-get update >/dev/null
+    echo "-----> Injecting packages: \$PACKAGES"
     apt-get install -y \$PACKAGES
-    echo "-----> Injected packages: \$PACKAGES"
 fi
 if [ -d $DIR/dpkg-packages ]; then
     for pkg in $DIR/dpkg-packages/*.deb; do
+        echo "-----> Injecting package: \$pkg"
         dpkg -i \$pkg
-        echo "-----> Injected package: \$pkg"
     done
 fi
 sleep 1 # wait so that docker run has not exited before docker attach
 EOF
   )
-  CID=$(docker run -d "$IMAGE" /bin/bash -e -c "$COMMAND")
-  local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP" "--change" "LABEL $DOKKU_CONTAINER_LABEL=")
+
+  CONTENT_SHA="$(echo -n "$CONTENT" | sha256sum | cut -d " " -f 1)"
+  if [[ "$("$DOCKER_BIN" images --quiet "dokku/$APP:$CONTENT_SHA" 2>/dev/null)" != "" ]]; then
+    dokku_log_info1 "Compatible extended app image found, skipping system package installation"
+    "$DOCKER_BIN" tag "dokku/$APP:$CONTENT_SHA" "$IMAGE"
+    fn-clean-extended-app-images "$APP" "dokku/$APP:$CONTENT_SHA"
+    return
+  fi
+
+  dokku_log_info1 "Extending app image with custom system packages"
+  CID=$("$DOCKER_BIN" run -d "$IMAGE" /bin/bash -e -c "$COMMAND")
+  local DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=sha-$APP" "--change" "LABEL $DOKKU_CONTAINER_LABEL=")
 
   "$DOCKER_BIN" attach "$CID"
   test "$("$DOCKER_BIN" wait "$CID")" -eq 0
   "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
+  "$DOCKER_BIN" rm "$CID" &>/dev/null || true
+  "$DOCKER_BIN" tag "$IMAGE" "dokku/$APP:$CONTENT_SHA"
+  fn-clean-extended-app-images "$APP" "dokku/$APP:$CONTENT_SHA"
 }
 
 hook-apt-pre-build-buildpack "$@"


### PR DESCRIPTION
By caching the generated command, we can then later check to see if there is an image that matches the cache, thereby avoiding the need to regenerate the image on every deploy.

Closes #23