### PR TITLE
fix: always bust cache when using a dpkg-packages file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The order of operations is:
 
 Utilizing the above files, the base build image will be extended for further use in the build process. If an already extended app image that is compatible with the desired changes is found, then the above will be skipped in favor of using the pre-existing image.
 
+Note that specifying packages within a `dpkg-packages` file will always bust the cache, as there is no way for the plugin to know if the files have changed between deploys.
+
 ### `apt-env`
 
 A file that can contain environment variables. Note that this is sourced, and should not contain arbitrary code.

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -34,6 +34,9 @@ hook-apt-pre-build-buildpack() {
       INJECT_PACKAGES=true
       local file_contents=$(<$file)
       CONTENT="${CONTENT}\n${file}\n${file_contents}"
+      if [[ "$file" == "dpkg-packages" ]]; then
+        CONTENT="${CONTENT}$(date +%s)"
+      fi
     fi
   done
 


### PR DESCRIPTION
If a dpkg-packages file is in use, the cache _must_ be busted. This is because the files in the repository are not guaranteed to be the same during each deploy - names can be reused - and the plugin does not know whether or not the deploy changes the files.

Instead of using a dpkg-packages file, users are encouraged to setup an apt repository and upload packages there.

Refs #23
Refs #32