### PR TITLE
fix: switch from dpkg to apt for installing dpkg-packages

### DIFF
--- a/internal-functions
+++ b/internal-functions
@@ -100,10 +100,9 @@ if [ -f $DIR/apt-packages ]; then
     apt-get install -y \$PACKAGES
 fi
 if [ -d $DIR/dpkg-packages ]; then
-    for pkg in $DIR/dpkg-packages/*.deb; do
-        echo "-----> Injecting package: \$pkg"
-        dpkg -i \$pkg
-    done
+    PACKAGES=\$(find $DIR/dpkg-packages -type f -name '*.deb' | tr "\\n" " ")
+    echo "-----> Injecting packages: \$PACKAGES"
+    apt install -y \$PACKAGES
 fi
 rm -rf /tmp/apt
 sleep 1 # wait so that docker run has not exited before docker attach


### PR DESCRIPTION
This allows us to install multiple packages in a single call, which fixes issues where any of the packages depend on one another.

I've confirmed this as working on an existing installation.

Closes #30