### PR TITLE
Save original sources.list before overriding and restore it at the end.

### DIFF
--- a/internal-functions
+++ b/internal-functions
@@ -71,6 +71,7 @@ if [ -d $DIR/apt-preferences ]; then
 fi
 if [ -f $DIR/apt-sources-list ]; then
     echo "-----> Using customized sources.list"
+    mv -v /etc/apt/sources.list /etc/apt/sources.list.orig
     mv -v $DIR/apt-sources-list /etc/apt/sources.list
 fi
 if [ -f $DIR/apt-repositories ]; then
@@ -105,6 +106,12 @@ if [ -d $DIR/dpkg-packages ]; then
         dpkg -i \$pkg
     done
 fi
+
+if [ -f /etc/apt/sources.list.orig ]; then
+    echo "-----> Restoring original sources.list"
+    mv -v /etc/apt/sources.list.orig /etc/apt/sources.list
+fi
+
 rm -rf /tmp/apt
 sleep 1 # wait so that docker run has not exited before docker attach
 EOF


### PR DESCRIPTION
When we inject an `apt-sources-list` file, the dokku-apt plugin overrides the original sources.list but, the original one is needed to install sqlite3 for the python buildpack.

This PR installs a patched version of dokku-apt that saves the original sources.list before doing apt/dpkg operations and restores it at the end of the process.
