### PR TITLE
allow updating ca certs

### DIFF
--- a/builder-create-dokku-image
+++ b/builder-create-dokku-image
@@ -48,6 +48,11 @@ hook-apt-builder-create-dokku-image() {
   eval "ARG_ARRAY=($DOCKER_ARGS)"
 
   COMMAND="$(fn-apt-command "$APP" "$DOKKU_IMAGE" "/tmp/apt")"
+
+  if [[ "$UPDATE_CA_CERTS" == "1" ]]; then
+      COMMAND="update-ca-certificates && $COMMAND"
+  fi
+
   DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$APP"
   CID=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -d "${ARG_ARRAY[@]}" "$IMAGE:apt" /bin/bash -e -c "$COMMAND")
 

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -16,7 +16,7 @@ hook-apt-pre-build-buildpack() {
     pushd "$SOURCECODE_WORK_DIR" >/dev/null
   fi
 
-  if [[ ! -d "dpkg-packages" ]]; then
+  if [[ ! -d "dpkg-packages" && "$UPDATE_CA_CERTS" != "1" ]]; then
     return
   fi
 
@@ -28,8 +28,15 @@ hook-apt-pre-build-buildpack() {
   declare -a ARG_ARRAY
   eval "ARG_ARRAY=($DOCKER_ARGS)"
 
-  dokku_log_info1 "Creating extended app image with custom system packages"
-  COMMAND="$(fn-apt-command "$APP" "$IMAGE" "$DIR")"
+  if [[ -d "dpkg-packages" ]]; then
+    dokku_log_info1 "Creating extended app image with custom system packages"
+    COMMAND="$(fn-apt-command "$APP" "$IMAGE" "$DIR")"
+  fi
+
+  if [[ "$UPDATE_CA_CERTS" == "1" ]]; then
+    COMMAND="update-ca-certificates && $COMMAND"
+  fi
+
   CID=$(docker run -d "${ARG_ARRAY[@]}" "$IMAGE" /bin/bash -e -c "$COMMAND")
 
   "$DOCKER_BIN" attach "$CID"


### PR DESCRIPTION
I would like to introduce the ability to run an `update-ca-certs` command, triggered by an `UPDATE_CA_CERTS` environment variable. 

This is needed to address custom certificates that are being mapped into a container from the host via `/usr/local/share/ca-certificates`. The custom certificates need to be injected into `/etc/ssl/certs/ca-certificates.crt` before running the apt installs as well as the buildpack dependencies. 

@josegonzalez could you please review / consider this proposed change.