### PR TITLE
Include DOKKU_IMAGE within generated apt sha

### DIFF
--- a/builder-create-dokku-image
+++ b/builder-create-dokku-image
@@ -15,7 +15,7 @@ hook-apt-builder-create-dokku-image() {
     return
   fi
 
-  CONTENT_SHA="$(fn-apt-fetch-sha "$SOURCECODE_WORK_DIR")"
+  CONTENT_SHA="$(fn-apt-fetch-sha "$SOURCECODE_WORK_DIR" "$DOKKU_IMAGE")"
   if [[ -z "$CONTENT_SHA" ]]; then
     return
   fi

--- a/builder-dokku-image
+++ b/builder-dokku-image
@@ -5,7 +5,7 @@ export DOCKER_BIN=${DOCKER_BIN:="docker"}
 source "$PLUGIN_AVAILABLE_PATH/apt/internal-functions"
 
 hook-apt-builder-dokku-image() {
-  declare BUILDER_TYPE="$1" APP="$2" SOURCECODE_WORK_DIR="$3"
+  declare BUILDER_TYPE="$1" APP="$2" SOURCECODE_WORK_DIR="$3" DOKKU_IMAGE="$4"
   local IMAGE="dokku/$APP"
   local CONTENT_SHA
 
@@ -13,7 +13,7 @@ hook-apt-builder-dokku-image() {
     return
   fi
 
-  CONTENT_SHA="$(fn-apt-fetch-sha "$SOURCECODE_WORK_DIR")"
+  CONTENT_SHA="$(fn-apt-fetch-sha "$SOURCECODE_WORK_DIR" "$DOKKU_IMAGE")"
   if [[ -z "$CONTENT_SHA" ]]; then
     return
   fi

--- a/internal-functions
+++ b/internal-functions
@@ -20,7 +20,7 @@ fn-clean-extended-app-images() {
 }
 
 fn-apt-fetch-sha() {
-  declare SOURCECODE_WORK_DIR="$1"
+  declare SOURCECODE_WORK_DIR="$1" DOKKU_IMAGE="$2"
   local APT_FILES CONTENT INJECT_PACKAGES file
 
   if [[ -d "$SOURCECODE_WORK_DIR/dpkg-packages" ]]; then
@@ -40,7 +40,7 @@ fn-apt-fetch-sha() {
     return
   fi
 
-  echo -n "$(<$PLUGIN_AVAILABLE_PATH/apt/plugin.toml)$CONTENT" | sha256sum | cut -d " " -f 1
+  echo -n "$(<$PLUGIN_AVAILABLE_PATH/apt/plugin.toml)${DOKKU_IMAGE}${CONTENT}" | sha256sum | cut -d " " -f 1
 }
 
 fn-apt-populate-work-dir() {


### PR DESCRIPTION
Without including the image, the compatible image may be incorrect when swapping out the underlying base image. This is extra bad when including new OS packages in a base image update.