### PR TITLE
docs: remove incorrect positional argument from installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ On your dokku server:
 
 ```sh
 # on dokku 0.18.x+
-sudo dokku plugin:install https://github.com/dokku-community/dokku-apt apt
+sudo dokku plugin:install https://github.com/dokku-community/dokku-apt
 ```
 
 ## Usage


### PR DESCRIPTION
The name should actually be specified as a flag - `--name` - and the current setup otherwise ignored it.