### PR TITLE
refactor: use expanded docker commands with container/image prefixes on subcommands

### DIFF
--- a/builder-create-dokku-image
+++ b/builder-create-dokku-image
@@ -24,7 +24,7 @@ hook-apt-builder-create-dokku-image() {
   trap "rm -rf '$TMP_WORK_DIR' >/dev/null" RETURN
   fn-apt-populate-work-dir "$SOURCECODE_WORK_DIR" "$TMP_WORK_DIR"
 
-  if [[ "$("$DOCKER_BIN" images --quiet "dokku/$APP:$CONTENT_SHA" 2>/dev/null)" != "" ]]; then
+  if [[ "$("$DOCKER_BIN" image ls --quiet "dokku/$APP:$CONTENT_SHA" 2>/dev/null)" != "" ]]; then
     dokku_log_info1 "Compatible extended app image found, skipping system package installation"
     fn-clean-extended-app-images "$APP" "dokku/$APP:$CONTENT_SHA"
     return
@@ -32,16 +32,16 @@ hook-apt-builder-create-dokku-image() {
 
   dokku_log_info1 "Creating extended app image with custom system packages"
   pushd "$TMP_WORK_DIR" >/dev/null
-  CID=$(tar -c . | "$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$DOKKU_IMAGE" /bin/bash -c "mkdir -p /tmp/apt && tar -xC /tmp/apt")
+  CID=$(tar -c . | "$DOCKER_BIN" container run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -i -a stdin "$DOKKU_IMAGE" /bin/bash -c "mkdir -p /tmp/apt && tar -xC /tmp/apt")
   popd >/dev/null
-  if test "$("$DOCKER_BIN" wait "$CID")" -ne 0; then
+  if test "$("$DOCKER_BIN" container wait "$CID")" -ne 0; then
     dokku_log_warn "Failure extracting apt files"
     return 1
   fi
 
   DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP" "--change" "LABEL $DOKKU_CONTAINER_LABEL=")
-  "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE:apt" >/dev/null
-  "$DOCKER_BIN" rm "$CID" &>/dev/null || true
+  "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE:apt" >/dev/null
+  "$DOCKER_BIN" container rm "$CID" &>/dev/null || true
 
   local DOCKER_ARGS=$(: | plugn trigger docker-args-build "$APP" "$BUILDER_TYPE")
   declare -a ARG_ARRAY
@@ -49,18 +49,18 @@ hook-apt-builder-create-dokku-image() {
 
   COMMAND="$(fn-apt-command "$APP" "$DOKKU_IMAGE" "/tmp/apt")"
   DOCKER_RUN_LABEL_ARGS="--label=com.dokku.app-name=$APP"
-  CID=$("$DOCKER_BIN" run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -d "${ARG_ARRAY[@]}" "$IMAGE:apt" /bin/bash -e -c "$COMMAND")
+  CID=$("$DOCKER_BIN" container run "${DOCKER_RUN_LABEL_ARGS[@]}" $DOKKU_GLOBAL_RUN_ARGS -d "${ARG_ARRAY[@]}" "$IMAGE:apt" /bin/bash -e -c "$COMMAND")
 
-  "$DOCKER_BIN" attach "$CID"
-  if test "$("$DOCKER_BIN" wait "$CID")" -ne 0; then
+  "$DOCKER_BIN" container attach "$CID"
+  if test "$("$DOCKER_BIN" container wait "$CID")" -ne 0; then
     dokku_log_warn "Failure installing system packages"
     return 1
   fi
 
   DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=sha-$APP" "--change" "LABEL $DOKKU_CONTAINER_LABEL=")
-  "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "dokku/$APP:$CONTENT_SHA" >/dev/null
-  "$DOCKER_BIN" rm "$CID" &>/dev/null || true
-  "$DOCKER_BIN" rmi "$IMAGE:apt" &>/dev/null || true
+  "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "dokku/$APP:$CONTENT_SHA" >/dev/null
+  "$DOCKER_BIN" container rm "$CID" &>/dev/null || true
+  "$DOCKER_BIN" image rm "$IMAGE:apt" &>/dev/null || true
   fn-clean-extended-app-images "$APP" "dokku/$APP:$CONTENT_SHA"
 }
 

--- a/builder-dokku-image
+++ b/builder-dokku-image
@@ -18,7 +18,7 @@ hook-apt-builder-dokku-image() {
     return
   fi
 
-  if [[ "$("$DOCKER_BIN" images --quiet "$IMAGE:$CONTENT_SHA" 2>/dev/null)" != "" ]]; then
+  if [[ "$("$DOCKER_BIN" image ls --quiet "$IMAGE:$CONTENT_SHA" 2>/dev/null)" != "" ]]; then
     echo "$IMAGE:$CONTENT_SHA"
     return
   fi

--- a/internal-functions
+++ b/internal-functions
@@ -9,12 +9,12 @@ fn-clean-extended-app-images() {
   local images
 
   # remove dangling extended app images
-  "$DOCKER_BIN" rmi $("$DOCKER_BIN" images --format 'dangling=true' --format "label=com.dokku.app-name=sha-$APP" --quiet) &>/dev/null || true
+  "$DOCKER_BIN" image rm $("$DOCKER_BIN" image ls --format 'dangling=true' --format "label=com.dokku.app-name=sha-$APP" --quiet) &>/dev/null || true
 
-  images="$("$DOCKER_BIN" images --filter "label=com.dokku.app-name=sha-$APP" --quiet)"
+  images="$("$DOCKER_BIN" image ls --filter "label=com.dokku.app-name=sha-$APP" --quiet)"
   for image in $images; do
-    if [[ "$("$DOCKER_BIN" inspect --format '{{(index .RepoTags 0)}}' "$image" 2>/dev/null)" != "$IMAGE" ]]; then
-      "$DOCKER_BIN" rmi "$image" &>/dev/null || true
+    if [[ "$("$DOCKER_BIN" image inspect --format '{{(index .RepoTags 0)}}' "$image" 2>/dev/null)" != "$IMAGE" ]]; then
+      "$DOCKER_BIN" image rm "$image" &>/dev/null || true
     fi
   done
 }

--- a/pre-build
+++ b/pre-build
@@ -32,15 +32,15 @@ hook-apt-pre-build() {
   COMMAND="$(fn-apt-command "$APP" "$IMAGE" "$DIR")"
   CID=$(docker run -d "${ARG_ARRAY[@]}" "$IMAGE" /bin/bash -e -c "$COMMAND")
 
-  "$DOCKER_BIN" attach "$CID"
-  if test "$("$DOCKER_BIN" wait "$CID")" -ne 0; then
+  "$DOCKER_BIN" container attach "$CID"
+  if test "$("$DOCKER_BIN" container wait "$CID")" -ne 0; then
     dokku_log_warn "Failure installing system packages"
     return 1
   fi
 
   DOCKER_COMMIT_LABEL_ARGS=("--change" "LABEL org.label-schema.schema-version=1.0" "--change" "LABEL org.label-schema.vendor=dokku" "--change" "LABEL com.dokku.app-name=$APP" "--change" "LABEL $DOKKU_CONTAINER_LABEL=")
-  "$DOCKER_BIN" commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
-  "$DOCKER_BIN" rm "$CID" &>/dev/null || true
+  "$DOCKER_BIN" container commit "${DOCKER_COMMIT_LABEL_ARGS[@]}" "$CID" "$IMAGE" >/dev/null
+  "$DOCKER_BIN" container rm "$CID" &>/dev/null || true
 }
 
 hook-apt-pre-build "$@"


### PR DESCRIPTION
This follows the pattern from the Dokku core, allowing us to better support alternative docker wrappers (such as podman).