### PR TITLE
fix: use herokuish image digest when computing the sha of the apt commands

### DIFF
--- a/internal-functions
+++ b/internal-functions
@@ -40,7 +40,10 @@ fn-apt-fetch-sha() {
     return
   fi
 
-  echo -n "$(<$PLUGIN_AVAILABLE_PATH/apt/plugin.toml)${DOKKU_IMAGE}${CONTENT}" | sha256sum | cut -d " " -f 1
+  local image_digest
+  image_digest="$("$DOCKER_BIN" image inspect --format='{{index .RepoDigests 0}}' "$DOKKU_IMAGE" 2>/dev/null || echo "$DOKKU_IMAGE")"
+
+  echo -n "$(<$PLUGIN_AVAILABLE_PATH/apt/plugin.toml)${image_digest}${CONTENT}" | sha256sum | cut -d " " -f 1
 }
 
 fn-apt-populate-work-dir() {


### PR DESCRIPTION
Previously, we would take the herokuish image as is, meaning we would sometimes have stale base images when herokuish was upgraded. This new path avoids this by taking a sha of the base image, and then re-applying the apt commands as expected.

Closes #48